### PR TITLE
Named Threads

### DIFF
--- a/src/main/java/ly/bit/nsq/NSQProducer.java
+++ b/src/main/java/ly/bit/nsq/NSQProducer.java
@@ -5,6 +5,8 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.client.params.CookiePolicy;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
@@ -58,6 +60,9 @@ public class NSQProducer {
 		this.httpclient = new DefaultHttpClient(cm);
 		this.setSocketTimeout(DEFAULT_SOCKET_TIMEOUT);
 		this.setConnectionTimeout(DEFAULT_CONNECTION_TIMEOUT);
+		// see https://code.google.com/p/crawler4j/issues/detail?id=136: potentially works around a jvm crash at
+		// org.apache.http.impl.cookie.BestMatchSpec.formatCookies(Ljava/util/List;)Ljava/util/List
+		this.httpclient.getParams().setParameter(ClientPNames.COOKIE_POLICY, CookiePolicy.IGNORE_COOKIES);
 
 		// register action for shutdown
 		Runtime.getRuntime().addShutdownHook(new Thread(){

--- a/src/main/java/ly/bit/nsq/util/NamedThreadFactory.java
+++ b/src/main/java/ly/bit/nsq/util/NamedThreadFactory.java
@@ -1,0 +1,40 @@
+package ly.bit.nsq.util;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Names threads so that thread dumps are easier to understand.
+ *
+ * @author oberwetter
+ */
+public class NamedThreadFactory implements ThreadFactory {
+	final private String nameFormat;
+	final private ThreadFactory decoratedFactory;
+	final private AtomicLong count;
+
+	public NamedThreadFactory(String nameFormat) {
+		this(nameFormat, Executors.defaultThreadFactory());
+	}
+
+	public NamedThreadFactory(String nameFormat, ThreadFactory decoratedFactory) {
+		if (nameFormat == null) {
+			throw new IllegalArgumentException("nameFormat cannot be null");
+		}
+		// make sure the format is valid
+		String.format(nameFormat, 0);
+
+		this.nameFormat = nameFormat;
+		this.decoratedFactory = decoratedFactory;
+		this.count = new AtomicLong(0);
+	}
+
+	@Override
+	public Thread newThread(Runnable runnable) {
+		Thread thread = this.decoratedFactory.newThread(runnable);
+		thread.setName(String.format(nameFormat, count.getAndIncrement()));
+		return thread;
+	}
+
+}

--- a/src/test/java/ly/bit/nsq/util/NamedThreadFactoryTest.java
+++ b/src/test/java/ly/bit/nsq/util/NamedThreadFactoryTest.java
@@ -1,0 +1,26 @@
+package ly.bit.nsq.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class NamedThreadFactoryTest {
+
+	@Test
+	public void testStuff() {
+		class MyRunnable implements Runnable {
+			@Override
+			public void run() {
+				// do nothing
+			}
+		}
+		NamedThreadFactory factory = new NamedThreadFactory("TheFactoryWuzHere-%d");
+
+		Thread t1 = factory.newThread(new MyRunnable());
+		assertEquals("TheFactoryWuzHere-0", t1.getName());
+
+		Thread t2 = factory.newThread(new MyRunnable());
+		assertEquals("TheFactoryWuzHere-1", t2.getName());
+	}
+
+}


### PR DESCRIPTION
Name the threads that we are creating with NSQProducer async posts to make stack traces and thread dumps more useful.
