### PR TITLE
Fix: Updated nsqlookupd protocol client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ly.bit</groupId>
     <artifactId>nsq</artifactId>
-    <version>0.0.1-m2mp</version>
+    <version>0.0.1-fclairamb</version>
     <name>Java NSQ Client</name>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ly.bit</groupId>
     <artifactId>nsq</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.0.1-m2mp</version>
     <name>Java NSQ Client</name>
     <dependencies>
         <dependency>

--- a/src/main/java/ly/bit/nsq/NSQReader.java
+++ b/src/main/java/ly/bit/nsq/NSQReader.java
@@ -142,7 +142,7 @@ public abstract class NSQReader {
 		if (stored != null){
 			return;
 		}
-        lookupdScheduler.scheduleAtFixedRate(new BasicLookupdJob(addr, this), 30, 30, SECONDS);
+        lookupdScheduler.scheduleAtFixedRate(new BasicLookupdJob(addr, this), 5, 30, SECONDS);
 	}
 
 	public String toString(){

--- a/src/main/java/ly/bit/nsq/lookupd/AbstractLookupd.java
+++ b/src/main/java/ly/bit/nsq/lookupd/AbstractLookupd.java
@@ -37,7 +37,10 @@ public abstract class AbstractLookupd {
 			 Iterator<JsonNode> prodItr = producers.getElements();
 			 while(prodItr.hasNext()){
 				 JsonNode producer = prodItr.next();
-				 String addr = producer.path("address").getTextValue();
+				 String addr = producer.path("broadcast_address").getTextValue();
+				 if ( addr == null ) { // We're keeping previous field compatibility, just in case
+					addr = producer.path("address").getTextValue();
+				 }
 				 int tcpPort = producer.path("tcp_port").getIntValue();
 				 outputs.add(addr + ":" + tcpPort);
 			 }


### PR DESCRIPTION
Tiny change to make it compatible with the [spec](http://nsq.io/clients/building_client_libraries.html#discovery) and the actual nsqlookupd server.

I guess the "address" field must come from a previous version and "somebody" must still use it.
