### PR TITLE
Fix: Updated nsqlookupd protocol client

### DIFF
--- a/src/main/java/ly/bit/nsq/lookupd/AbstractLookupd.java
+++ b/src/main/java/ly/bit/nsq/lookupd/AbstractLookupd.java
@@ -37,7 +37,10 @@ public abstract class AbstractLookupd {
 			 Iterator<JsonNode> prodItr = producers.getElements();
 			 while(prodItr.hasNext()){
 				 JsonNode producer = prodItr.next();
-				 String addr = producer.path("address").getTextValue();
+				 String addr = producer.path("broadcast_address").getTextValue();
+				 if ( addr == null ) { // We're keeping previous field compatibility, just in case
+					addr = producer.path("address").getTextValue();
+				 }
 				 int tcpPort = producer.path("tcp_port").getIntValue();
 				 outputs.add(addr + ":" + tcpPort);
 			 }


### PR DESCRIPTION
(replaces #11)

Tiny change to make it compatible with the [spec](http://nsq.io/clients/building_client_libraries.html#discovery) and the actual nsqlookupd server.

I guess the "address" field must come from a previous version and "somebody" must still use it.
