### PR TITLE
when server was powerd off, client tcp status always ESTABLISHED.

### DIFF
--- a/src/main/java/ly/bit/nsq/BasicConnection.java
+++ b/src/main/java/ly/bit/nsq/BasicConnection.java
@@ -26,6 +26,7 @@ public class BasicConnection extends Connection {
 		this.reader = reader;
 		this.port = port;
 		this.sock = new Socket();
+		this.sock.setKeepAlive(true);
 	}
 
 	@Override


### PR DESCRIPTION
1.server side powered off and restart
2.client always keep tcp status as ESTABLISHED.